### PR TITLE
Chore: Remove python version dependency

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.poetry.dependencies]
-python = "^3.9"
-
 [ayon.runtimeDependencies]
 pyairtable = "^3.1.1"
 pydantic = "^2.10.3"


### PR DESCRIPTION
## Changelog Description
Remove python version requirement from client's pyproject.toml .

## Additional review information
The requirement would not work with last AYON launcher release which uses python 3.11.

## Testing notes:
1. Validate changes.